### PR TITLE
Commit message gen: Use user input as starting point

### DIFF
--- a/app/src/lib/ai/prompts.ts
+++ b/app/src/lib/ai/prompts.ts
@@ -1,9 +1,42 @@
-import { type Prompt, MessageRole } from '$lib/ai/types';
+import {
+	type Prompt,
+	MessageRole,
+	PromptDirective,
+	PromptTemplateParam,
+	type CustomPromptDirective,
+	type InternalPrompt,
+	InternalPromptMessageType
+} from '$lib/ai/types';
 
-export const SHORT_DEFAULT_COMMIT_TEMPLATE: Prompt = [
+export function embedExistingCommitMessage(commitMessage: string): CustomPromptDirective {
+	return `Here is the existing commit MESSAGE:\n\`\`\`\n${commitMessage.trim()}\n\`\`\`` as CustomPromptDirective;
+}
+
+export function embedPromptParameter(
+	promptContent: string,
+	param: PromptTemplateParam,
+	value: PromptDirective | CustomPromptDirective | undefined
+): string {
+	const paramValue = value ? value + '\n' : '';
+	const result = promptContent.replaceAll(param, paramValue);
+	return result;
+}
+
+export function filterInternalPromptMessages(
+	messages: InternalPrompt,
+	directive: PromptDirective
+): InternalPrompt {
+	return messages.filter(
+		(message) =>
+			message.type !== InternalPromptMessageType.Example || message.forDirective === directive
+	);
+}
+
+export const SHORT_DEFAULT_COMMIT_TEMPLATE: InternalPrompt = [
 	{
+		type: InternalPromptMessageType.MainPrompt,
 		role: MessageRole.User,
-		content: `Please could you write a commit message for my changes.
+		content: `${PromptTemplateParam.CreateOrRewriteMessage}
 Only respond with the commit message. Don't give any notes.
 Explain what were the changes and why the changes were done.
 Focus the most important changes.
@@ -12,21 +45,22 @@ Use a semantic commit prefix.
 Hard wrap lines at 72 characters.
 Ensure the title is only 50 characters.
 Do not start any lines with the hash symbol.
-%{brief_style}
-%{emoji_style}
+${PromptTemplateParam.BriefStyle + PromptTemplateParam.EmojiStyle + PromptTemplateParam.ExistingMessage}
 
 Here is my git diff:
 \`\`\`
-%{diff}
+${PromptTemplateParam.Diff}
 \`\`\`
 `
 	}
 ];
 
-export const LONG_DEFAULT_COMMIT_TEMPLATE: Prompt = [
+export const LONG_DEFAULT_COMMIT_TEMPLATE: InternalPrompt = [
 	{
+		type: InternalPromptMessageType.Example,
+		forDirective: PromptDirective.WriteCommitMessage,
 		role: MessageRole.User,
-		content: `Please could you write a commit message for my changes.
+		content: `${PromptDirective.WriteCommitMessage}.
 Explain what were the changes and why the changes were done.
 Focus the most important changes.
 Use the present tense.
@@ -35,6 +69,7 @@ Hard wrap lines at 72 characters.
 Ensure the title is only 50 characters.
 Do not start any lines with the hash symbol.
 Only respond with the commit message.
+${PromptDirective.CommitMessageDontUseEmoji}
 
 Here is my git diff:
 \`\`\`
@@ -57,10 +92,55 @@ index 1cbfaa2..7aeebcf 100644
 `
 	},
 	{
+		type: InternalPromptMessageType.Example,
+		forDirective: PromptDirective.WriteCommitMessage,
 		role: MessageRole.Assistant,
 		content: `Typing utilities: Check for array of type
 
 Added an utility function to check whether a given value is an array of a specific type.`
+	},
+	{
+		type: InternalPromptMessageType.Example,
+		forDirective: PromptDirective.ImproveCommitMessage,
+		role: MessageRole.User,
+		content: `${PromptDirective.ImproveCommitMessage}.
+Explain what were the changes and why the changes were done.
+Focus the most important changes.
+Use the present tense.
+Use a semantic commit prefix.
+Hard wrap lines at 72 characters.
+Ensure the title is only 50 characters.
+Do not start any lines with the hash symbol.
+Only respond with the commit message.
+${embedExistingCommitMessage(`Sun is out`)}
+
+Here is my git diff:
+\`\`\`
+diff --git a/src/utils/typing.ts b/src/utils/typing.ts
+index 1cbfaa2..7aeebcf 100644
+--- a/src/utils/typing.ts
++++ b/src/utils/typing.ts
+@@ -35,3 +35,10 @@ export function isNonEmptyObject(something: unknown): something is UnknownObject
+     (Object.keys(something).length > 0 || Object.getOwnPropertySymbols(something).length > 0)
+   );
+ }
++
++export function isArrayOf<T>(
++  something: unknown,
++  check: (value: unknown) => value is T
++): something is T[] {
++  return Array.isArray(something) && something.every(check);
++}
+\`\`\`
+`
+	},
+	{
+		type: InternalPromptMessageType.Example,
+		forDirective: PromptDirective.ImproveCommitMessage,
+		role: MessageRole.Assistant,
+		content: `Sun is out
+
+Added a helper function to check whether a given value is an array of a specific type.`
 	},
 	...SHORT_DEFAULT_COMMIT_TEMPLATE
 ];
@@ -68,7 +148,7 @@ Added an utility function to check whether a given value is an array of a specif
 export const SHORT_DEFAULT_BRANCH_TEMPLATE: Prompt = [
 	{
 		role: MessageRole.User,
-		content: `Please could you write a branch name for my changes.
+		content: `${PromptDirective.WriteBranchName}
 A branch name represent a brief description of the changes in the diff (branch).
 Branch names should contain no whitespace and instead use dashes to separate words.
 Branch names should contain a maximum of 5 words.
@@ -76,7 +156,7 @@ Only respond with the branch name.
 
 Here is my git diff:
 \`\`\`
-%{diff}
+${PromptTemplateParam.Diff}
 \`\`\`
 `
 	}
@@ -85,7 +165,7 @@ Here is my git diff:
 export const LONG_DEFAULT_BRANCH_TEMPLATE: Prompt = [
 	{
 		role: MessageRole.User,
-		content: `Please could you write a branch name for my changes.
+		content: `${PromptDirective.WriteBranchName}
 A branch name represent a brief description of the changes in the diff (branch).
 Branch names should contain no whitespace and instead use dashes to separate words.
 Branch names should contain a maximum of 5 words.

--- a/app/src/lib/ai/types.ts
+++ b/app/src/lib/ai/types.ts
@@ -1,4 +1,5 @@
 import type { Persisted } from '$lib/persisted/persisted';
+import type { Branded } from '$lib/utils/branding';
 
 export enum ModelKind {
 	OpenAI = 'openai',
@@ -32,11 +33,53 @@ export interface PromptMessage {
 
 export type Prompt = PromptMessage[];
 
+export type CustomPromptDirective = Branded<string, 'CustomPromptDirective'>;
+
+export enum PromptDirective {
+	WriteCommitMessage = 'Please could you write a commit message for my changes.',
+	ImproveCommitMessage = "Please complete the commit message leaving the existing commit MESSAGE as is. DON't change the existing MESSAGE, just add to it.",
+	CommitMessageBrevity = 'The commit message must be only one sentence and as short as possible.',
+	CommitMessageUseEmoji = 'Use emoji in the title prefix. Add it if not present.',
+	CommitMessageDontUseEmoji = "Don't use any emoji.",
+	WriteBranchName = 'Please could you write a branch name for my changes.'
+}
+
+export enum PromptTemplateParam {
+	CreateOrRewriteMessage = '%{create_or_rewrite_message}',
+	ExistingMessage = '%{existing_message}',
+	Diff = '%{diff}',
+	BriefStyle = '%{brief_style}',
+	EmojiStyle = '%{emoji_style}'
+}
+
+export enum InternalPromptMessageType {
+	Example = 'example',
+	MainPrompt = 'main-prompt'
+}
+interface InternalPromptMessageExample extends PromptMessage {
+	type: InternalPromptMessageType.Example;
+	forDirective: PromptDirective;
+}
+
+interface InternalPromptMessageMainPrompt extends PromptMessage {
+	type: InternalPromptMessageType.MainPrompt;
+}
+
+export type InternalPromptMessage = InternalPromptMessageExample | InternalPromptMessageMainPrompt;
+
+export type InternalPrompt = InternalPromptMessage[];
+
+export function isInternalPromptMessageExample(
+	message: PromptMessage
+): message is InternalPromptMessageExample {
+	return (message as InternalPromptMessage).type === InternalPromptMessageType.Example;
+}
+
 export interface AIClient {
 	evaluate(prompt: Prompt): Promise<string>;
 
 	defaultBranchTemplate: Prompt;
-	defaultCommitTemplate: Prompt;
+	defaultCommitTemplate: InternalPrompt;
 }
 
 export type UserPrompt = {

--- a/app/src/lib/config/config.ts
+++ b/app/src/lib/config/config.ts
@@ -20,6 +20,13 @@ export function projectCommitGenerationUseEmojis(projectId: string): Persisted<b
 	return persisted(false, key + projectId);
 }
 
+export function projectCommitGenerationImproveExistingMessage(
+	projectId: string
+): Persisted<boolean> {
+	const key = 'projectCommitGenerationImproveExistingMessage_';
+	return persisted(false, key + projectId);
+}
+
 export enum ListPRsFilter {
 	All = 'ALL',
 	ExcludeBots = 'EXCLUDE_BOTS',

--- a/app/src/lib/utils/branding.ts
+++ b/app/src/lib/utils/branding.ts
@@ -1,0 +1,1 @@
+export type Branded<T, Brand extends string> = T & { __brand: Brand };


### PR DESCRIPTION
Related to #4060

Flag to have the commit generation only improve or reword the given user input.

- The flag is persisted just as the the brevity and emoji use
- Add types prompt parameters and directives for improved type guarding and **dynamic meta-prompt generation**
- Add directive-specific meta-prompting for Ollama client.

![improve-user-input](https://github.com/gitbutlerapp/gitbutler/assets/35891811/f5739220-ec09-4a55-990b-f0297e323cd7)

Also:
- Add branded types util (this might be just as well moved to the `typeguards.ts`)
- Gracefully handle Network Errors on the Ollama Client (e.g. when the Ollama server is not running)
<img width="568" alt="Screenshot 2024-06-11 at 10 00 33" src="https://github.com/gitbutlerapp/gitbutler/assets/35891811/0b58fced-5b4f-4e7c-9e36-8c4ff6da14f2">

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces a new feature to improve or reword existing commit messages based on user input, enhances type guarding and meta-prompt generation, and updates commit message templates. It also includes a fix for handling network errors in the Ollama client.

- **New Features**:
    - Introduced a flag to improve or reword existing commit messages based on user input.
    - Added directive-specific meta-prompting for the Ollama client.
- **Bug Fixes**:
    - Gracefully handle network errors in the Ollama client, providing a clear error message when the server is not running.
- **Enhancements**:
    - Enhanced type guarding and dynamic meta-prompt generation with new types and prompt parameters.
    - Added branded types utility for improved type safety.
    - Updated commit message templates to support new directives and parameters.

<!-- Generated by sourcery-ai[bot]: end summary -->