### PR TITLE
WIP: Hunk Splitting

### DIFF
--- a/app/src/lib/components/BranchCard.svelte
+++ b/app/src/lib/components/BranchCard.svelte
@@ -124,10 +124,9 @@
 	}
 
 	function acceptBranchDrop(data: any) {
-		if (
-			(data instanceof DraggableHunk || data instanceof DraggableSplitHunk) &&
-			data.branchId != branch.id
-		) {
+		if (data instanceof DraggableHunk && data.branchId != branch.id) {
+			return !data.hunk.locked;
+		} else if (data instanceof DraggableSplitHunk && data.branchId != branch.id) {
 			return !data.hunk.locked;
 		} else if (data instanceof DraggableFile && data.branchId && data.branchId != branch.id) {
 			return !data.files.some((f) => f.locked);
@@ -150,8 +149,12 @@
 				(newOwnership + '\n' + branch.ownership).trim()
 			);
 		} else if (data instanceof DraggableSplitHunk) {
-			// XXX DEBUG
-			console.log('dragged split commit: ', data);
+			branchController.splitHunkAndUpdateBranchOwnership(
+				branch.id,
+				data.branchId,
+				data.hunk,
+				data.lines
+			);
 		}
 	}
 

--- a/app/src/lib/components/BranchCard.svelte
+++ b/app/src/lib/components/BranchCard.svelte
@@ -21,7 +21,8 @@
 		DraggableCommit,
 		DraggableFile,
 		DraggableHunk,
-		DraggableRemoteCommit
+		DraggableRemoteCommit,
+		DraggableSplitHunk
 	} from '$lib/dragging/draggables';
 	import { dropzone } from '$lib/dragging/dropzone';
 	import { showError } from '$lib/notifications/toasts';
@@ -123,7 +124,10 @@
 	}
 
 	function acceptBranchDrop(data: any) {
-		if (data instanceof DraggableHunk && data.branchId != branch.id) {
+		if (
+			(data instanceof DraggableHunk || data instanceof DraggableSplitHunk) &&
+			data.branchId != branch.id
+		) {
 			return !data.hunk.locked;
 		} else if (data instanceof DraggableFile && data.branchId && data.branchId != branch.id) {
 			return !data.files.some((f) => f.locked);
@@ -132,7 +136,7 @@
 		}
 	}
 
-	function onBranchDrop(data: DraggableHunk | DraggableFile) {
+	function onBranchDrop(data: DraggableHunk | DraggableFile | DraggableSplitHunk) {
 		if (data instanceof DraggableHunk) {
 			const newOwnership = `${data.hunk.filePath}:${data.hunk.id}`;
 			branchController.updateBranchOwnership(
@@ -145,6 +149,9 @@
 				branch.id,
 				(newOwnership + '\n' + branch.ownership).trim()
 			);
+		} else if (data instanceof DraggableSplitHunk) {
+			// XXX DEBUG
+			console.log('dragged split commit: ', data);
 		}
 	}
 

--- a/app/src/lib/components/BranchCard.svelte
+++ b/app/src/lib/components/BranchCard.svelte
@@ -153,7 +153,7 @@
 				branch.id,
 				data.branchId,
 				data.hunk,
-				data.lines
+				data.getClaims()
 			);
 		}
 	}

--- a/app/src/lib/components/HunkLine.svelte
+++ b/app/src/lib/components/HunkLine.svelte
@@ -2,8 +2,8 @@
 	import { create } from '$lib/components/Differ/CodeHighlighter';
 	import { SectionType } from '$lib/utils/fileSections';
 	import { createEventDispatcher } from 'svelte';
-	import type { Line } from '$lib/utils/fileSections';
 	import { writable } from 'svelte/store';
+	import type { Line } from '$lib/utils/fileSections';
 
 	export let line: Line;
 	export let sectionType: SectionType;
@@ -15,7 +15,7 @@
 	export let draggingDisabled: boolean = false;
 	export let tabSize = 4;
 	export let showSplitSelect = false;
-	export let selectedForSplit = writable<Boolean>(false);
+	export let selectedForSplit = writable<boolean>(false);
 
 	const dispatch = createEventDispatcher<{ selected: boolean }>();
 

--- a/app/src/lib/components/HunkLine.svelte
+++ b/app/src/lib/components/HunkLine.svelte
@@ -3,6 +3,7 @@
 	import { SectionType } from '$lib/utils/fileSections';
 	import { createEventDispatcher } from 'svelte';
 	import type { Line } from '$lib/utils/fileSections';
+	import { writable } from 'svelte/store';
 
 	export let line: Line;
 	export let sectionType: SectionType;
@@ -13,6 +14,8 @@
 	export let readonly: boolean = false;
 	export let draggingDisabled: boolean = false;
 	export let tabSize = 4;
+	export let showSplitSelect = false;
+	export let selectedForSplit = writable<Boolean>(false);
 
 	const dispatch = createEventDispatcher<{ selected: boolean }>();
 
@@ -36,10 +39,17 @@
 	}
 
 	$: isSelected = selectable && selected;
+	$: splitSelected = false;
+	$: selectedForSplit.set(splitSelected);
 </script>
 
 <div class="code-line" role="group" style="--tab-size: {tabSize}" on:contextmenu|preventDefault>
 	<div class="code-line__numbers-line">
+		{#if showSplitSelect && !draggingDisabled && !readonly}
+			<div>
+				<input type="checkbox" name="select" bind:checked={splitSelected} />
+			</div>
+		{/if}
 		<button
 			on:click={() => selectable && dispatch('selected', !selected)}
 			class="numbers-line-count"

--- a/app/src/lib/components/HunkViewer.svelte
+++ b/app/src/lib/components/HunkViewer.svelte
@@ -8,10 +8,10 @@
 	import { DraggableHunk, DraggableSplitHunk } from '$lib/dragging/draggables';
 	import { SETTINGS, type Settings } from '$lib/settings/userSettings';
 	import { getContext, getContextStoreBySymbol, maybeGetContextStore } from '$lib/utils/context';
+	import { SectionType, type HunkSection, type Line } from '$lib/utils/fileSections';
 	import { Ownership } from '$lib/vbranches/ownership';
 	import { Branch, type Hunk } from '$lib/vbranches/types';
 	import { onDestroy } from 'svelte';
-	import { SectionType, type HunkSection, type Line } from '$lib/utils/fileSections';
 	import { writable, type Writable } from 'svelte/store';
 
 	export let viewport: HTMLDivElement | undefined = undefined;

--- a/app/src/lib/components/HunkViewer.svelte
+++ b/app/src/lib/components/HunkViewer.svelte
@@ -11,7 +11,7 @@
 	import { Ownership } from '$lib/vbranches/ownership';
 	import { Branch, type Hunk } from '$lib/vbranches/types';
 	import { onDestroy } from 'svelte';
-	import type { HunkSection, Line } from '$lib/utils/fileSections';
+	import { SectionType, type HunkSection, type Line } from '$lib/utils/fileSections';
 	import { writable, type Writable } from 'svelte/store';
 
 	export let viewport: HTMLDivElement | undefined = undefined;
@@ -76,6 +76,12 @@
 </script>
 
 <div class="scrollable">
+	{#if canSplit}
+		<div>
+			<input type="checkbox" name="split" bind:checked={isSplitting} />
+			<label for="split">Split</label>
+		</div>
+	{/if}
 	<div
 		bind:this={viewport}
 		tabindex="0"
@@ -101,12 +107,7 @@
 			{:else}
 				{#each section.subSections as subsection}
 					{@const hunk = section.hunk}
-					{#if canSplit}
-						<div>
-							<input type="checkbox" name="split" bind:checked={isSplitting} />
-							<label for="split">Split</label>
-						</div>
-					{/if}
+
 					{#each subsection.lines.slice(0, subsection.expanded ? subsection.lines.length : 0) as line}
 						<HunkLine
 							{line}
@@ -115,7 +116,7 @@
 							{minWidth}
 							{selectable}
 							{draggingDisabled}
-							showSplitSelect={isSplitting}
+							showSplitSelect={isSplitting && subsection.sectionType !== SectionType.Context}
 							selectedForSplit={getLineStore(line)}
 							tabSize={$userSettings.tabSize}
 							selected={$selectedOwnership?.contains(hunk.filePath, hunk.id)}

--- a/app/src/lib/dragging/draggables.ts
+++ b/app/src/lib/dragging/draggables.ts
@@ -1,6 +1,6 @@
 import { get, type Readable } from 'svelte/store';
 import type { Line } from '$lib/utils/fileSections';
-import type { AnyCommit, AnyFile, Commit, Hunk, RemoteCommit } from '../vbranches/types';
+import type { AnyCommit, AnyFile, Branch, Commit, Hunk, RemoteCommit } from '../vbranches/types';
 
 export function nonDraggable() {
 	return {
@@ -53,4 +53,4 @@ export class DraggableRemoteCommit {
 	) {}
 }
 
-export type Draggable = DraggableFile | DraggableHunk | DraggableCommit;
+export type Draggable = DraggableFile | DraggableHunk | DraggableCommit | DraggableSplitHunk;

--- a/app/src/lib/dragging/draggables.ts
+++ b/app/src/lib/dragging/draggables.ts
@@ -1,5 +1,4 @@
 import { get, type Readable } from 'svelte/store';
-import type { Line } from '$lib/utils/fileSections';
 import type { AnyCommit, AnyFile, Commit, Hunk, RemoteCommit } from '../vbranches/types';
 
 export function nonDraggable() {
@@ -13,7 +12,7 @@ export class DraggableSplitHunk {
 	constructor(
 		public readonly branchId: string,
 		public readonly hunk: Hunk,
-		public readonly lines: Set<Line>
+		public readonly getClaims: () => (boolean | null)[]
 	) {}
 }
 

--- a/app/src/lib/dragging/draggables.ts
+++ b/app/src/lib/dragging/draggables.ts
@@ -1,6 +1,6 @@
 import { get, type Readable } from 'svelte/store';
 import type { Line } from '$lib/utils/fileSections';
-import type { AnyCommit, AnyFile, Branch, Commit, Hunk, RemoteCommit } from '../vbranches/types';
+import type { AnyCommit, AnyFile, Commit, Hunk, RemoteCommit } from '../vbranches/types';
 
 export function nonDraggable() {
 	return {

--- a/app/src/lib/dragging/draggables.ts
+++ b/app/src/lib/dragging/draggables.ts
@@ -1,3 +1,5 @@
+import { get, type Readable } from 'svelte/store';
+import type { Line } from '$lib/utils/fileSections';
 import type { AnyCommit, AnyFile, Commit, Hunk, RemoteCommit } from '../vbranches/types';
 
 export function nonDraggable() {
@@ -5,6 +7,14 @@ export function nonDraggable() {
 		disabled: true,
 		data: undefined
 	};
+}
+
+export class DraggableSplitHunk {
+	constructor(
+		public readonly branchId: string,
+		public readonly hunk: Hunk,
+		public readonly lines: Set<Line>
+	) {}
 }
 
 export class DraggableHunk {

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -195,10 +195,12 @@ export class BranchController {
 		try {
 			await invoke<void>('split_hunk_and_update_virtual_branch', {
 				projectId: this.projectId,
-				branchId,
-				sourceBranchId,
-				hunkId: hunk.id,
-				lines: Array.from(lines).map((l) => [l.afterLineNumber, l.beforeLineNumber])
+				branch: {
+					id: branchId,
+					source_id: sourceBranchId,
+					ownership: `${hunk.filePath}:${hunk.id}-${hunk.hash}`,
+					lines: Array.from(lines).map((l) => [l.afterLineNumber, l.beforeLineNumber])
+				}
 			});
 		} catch (err) {
 			showError('Failed to split hunk and update ownership', err);

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -200,6 +200,7 @@ export class BranchController {
 				projectId: this.projectId,
 				branch: {
 					hunk_hash: hunk.hash,
+					split_from: hunk.splitFrom,
 					// Convert to an array of branch IDs (none == context line)
 					// such that each line corresponds to the branch that should own it.
 					lines: Array.from(claims).map((l) => (l === null ? null : l ? branchId : sourceBranchId))

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -3,10 +3,10 @@ import { showError, showToast } from '$lib/notifications/toasts';
 import * as toasts from '$lib/utils/toasts';
 import posthog from 'posthog-js';
 import type { RemoteBranchService } from '$lib/stores/remoteBranches';
+import type { Line } from '$lib/utils/fileSections';
 import type { BaseBranchService } from './baseBranch';
 import type { Branch, Hunk, LocalFile } from './types';
 import type { VirtualBranchService } from './virtualBranch';
-import type { Line } from '$lib/utils/fileSections';
 
 export class BranchController {
 	constructor(

--- a/app/src/lib/vbranches/branchController.ts
+++ b/app/src/lib/vbranches/branchController.ts
@@ -6,6 +6,7 @@ import type { RemoteBranchService } from '$lib/stores/remoteBranches';
 import type { BaseBranchService } from './baseBranch';
 import type { Branch, Hunk, LocalFile } from './types';
 import type { VirtualBranchService } from './virtualBranch';
+import type { Line } from '$lib/utils/fileSections';
 
 export class BranchController {
 	constructor(
@@ -182,6 +183,25 @@ export class BranchController {
 			});
 		} catch (err) {
 			showError('Failed to update hunk ownership', err);
+		}
+	}
+
+	async splitHunkAndUpdateBranchOwnership(
+		branchId: string,
+		sourceBranchId: string,
+		hunk: Hunk,
+		lines: Set<Line>
+	) {
+		try {
+			await invoke<void>('split_hunk_and_update_virtual_branch', {
+				projectId: this.projectId,
+				branchId,
+				sourceBranchId,
+				hunkId: hunk.id,
+				lines: Array.from(lines).map((l) => [l.afterLineNumber, l.beforeLineNumber])
+			});
+		} catch (err) {
+			showError('Failed to split hunk and update ownership', err);
 		}
 	}
 

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -22,6 +22,7 @@ export class Hunk {
 	modifiedAt!: Date;
 	filePath!: string;
 	hash?: string;
+	splitFrom?: string;
 	locked!: boolean;
 	@Type(() => HunkLock)
 	lockedTo!: HunkLock[];

--- a/crates/gitbutler-core/src/git/diff.rs
+++ b/crates/gitbutler-core/src/git/diff.rs
@@ -10,7 +10,7 @@ use tracing::instrument;
 use super::Repository;
 use crate::git;
 use crate::id::Id;
-use crate::virtual_branches::split::SplitEntry;
+use crate::virtual_branches::branch::HunkHash;
 use crate::virtual_branches::Branch;
 
 pub type DiffByPathMap = HashMap<PathBuf, FileDiff>;
@@ -54,8 +54,7 @@ pub struct GitHunk {
     /// The `+`, `-` or ` ` prefixed lines of the diff produced by `git2`, along with their line separator.
     #[serde(rename = "diff", serialize_with = "crate::serde::as_string_lossy")]
     pub diff_lines: BString,
-    #[serde(skip)]
-    pub split: Option<SplitEntry>,
+    pub split_from: Option<HunkHash>,
     pub binary: bool,
     pub locked_to: Box<[HunkLock]>,
     pub change_type: ChangeType,
@@ -72,7 +71,7 @@ impl GitHunk {
             new_start: 0,
             new_lines: 0,
             diff_lines: hex_id.into(),
-            split: None,
+            split_from: None,
             binary: true,
             change_type,
             locked_to: Box::new([]),
@@ -87,7 +86,7 @@ impl GitHunk {
             new_start: 0,
             new_lines: 0,
             diff_lines: Default::default(),
-            split: None,
+            split_from: None,
             binary: false,
             change_type: ChangeType::Modified,
             locked_to: Box::new([]),
@@ -323,7 +322,7 @@ pub fn hunks_by_filepath(repo: Option<&Repository>, diff: &git2::Diff) -> Result
                                         new_start,
                                         new_lines,
                                         diff_lines: line.into_owned(),
-                                        split: None,
+                                        split_from: None,
                                         binary: false,
                                         change_type,
                                         locked_to: Box::new([]),
@@ -431,7 +430,7 @@ pub fn reverse_hunk(hunk: &GitHunk) -> Option<GitHunk> {
             new_start: hunk.old_start,
             new_lines: hunk.old_lines,
             diff_lines: diff,
-            split: None,
+            split_from: hunk.split_from,
             binary: hunk.binary,
             change_type: hunk.change_type,
             locked_to: Box::new([]),

--- a/crates/gitbutler-core/src/lib.rs
+++ b/crates/gitbutler-core/src/lib.rs
@@ -58,6 +58,17 @@ pub mod serde {
         format!("{v:x}").serialize(s)
     }
 
+    pub fn hash_to_hex_opt<S>(v: &Option<HunkHash>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        if let Some(v) = v {
+            hash_to_hex(v, s)
+        } else {
+            s.serialize_none()
+        }
+    }
+
     pub fn as_time_seconds_from_unix_epoch<S>(v: &git2::Time, s: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,

--- a/crates/gitbutler-core/src/projects/project.rs
+++ b/crates/gitbutler-core/src/projects/project.rs
@@ -6,7 +6,10 @@ use std::{
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    git, id::Id, types::default_true::DefaultTrue, virtual_branches::VirtualBranchesHandle,
+    git,
+    id::Id,
+    types::default_true::DefaultTrue,
+    virtual_branches::{split::SplitDatabase, VirtualBranchesHandle},
 };
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
@@ -101,6 +104,13 @@ impl Project {
             .as_ref()
             .map(|api| api.code_git_url.is_some())
             .unwrap_or_default()
+    }
+
+    pub fn splits(&self) -> SplitDatabase {
+        // TODO(qix-): There's no great way to store this on the Project struct.
+        // TODO(qix-): Thus, we have to make the consumers load and store it.
+        // TODO(qix-): Sorry.
+        SplitDatabase::new(self.gb_dir().join("splits.json"))
     }
 
     /// Returns the path to the directory containing the `GitButler` state for this project.

--- a/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/hunk.rs
@@ -1,11 +1,10 @@
 use std::{fmt::Display, ops::RangeInclusive, str::FromStr};
 
+use super::HunkHash;
 use anyhow::{anyhow, Context, Result};
 use bstr::ByteSlice;
 
 use crate::git::diff;
-
-pub type HunkHash = md5::Digest;
 
 #[derive(Debug, Eq, Clone)]
 pub struct Hunk {
@@ -93,7 +92,7 @@ impl FromStr for Hunk {
             None
         };
 
-        Hunk::new(start, end, hash, timestamp_ms)
+        Hunk::new(start, end, hash.map(Into::into), timestamp_ms)
     }
 }
 
@@ -175,12 +174,12 @@ impl Hunk {
         diff.lines_with_terminator()
             .skip(1) // skip the first line which is the diff header.
             .for_each(|line| ctx.consume(line));
-        ctx.compute()
+        ctx.compute().into()
     }
 
     /// Produce a hash of `input` using the same function as [`Self::hash_diff()`], but without any assumptions.
     #[inline]
     pub fn hash<S: AsRef<[u8]>>(input: S) -> HunkHash {
-        md5::compute(input.as_ref())
+        md5::compute(input.as_ref()).into()
     }
 }

--- a/crates/gitbutler-core/src/virtual_branches/branch/hunk_hash.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/hunk_hash.rs
@@ -1,0 +1,84 @@
+use std::{
+    fmt,
+    ops::{Deref, DerefMut},
+};
+
+#[repr(transparent)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HunkHash(md5::Digest);
+
+impl Default for HunkHash {
+    fn default() -> Self {
+        HunkHash(md5::Digest([0; 16]))
+    }
+}
+
+impl From<md5::Digest> for HunkHash {
+    fn from(digest: md5::Digest) -> Self {
+        HunkHash(digest)
+    }
+}
+
+impl From<HunkHash> for md5::Digest {
+    fn from(hash: HunkHash) -> Self {
+        hash.0
+    }
+}
+
+impl serde::Serialize for HunkHash {
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> std::result::Result<S::Ok, S::Error> {
+        serializer.serialize_str(hex::encode(self.0 .0).as_str())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for HunkHash {
+    fn deserialize<D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> std::result::Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        let mut buf = [0u8; 16];
+        hex::decode_to_slice(s, &mut buf).map_err(serde::de::Error::custom)?;
+        Ok(md5::Digest(buf).into())
+    }
+}
+
+impl AsRef<md5::Digest> for HunkHash {
+    fn as_ref(&self) -> &md5::Digest {
+        &self.0
+    }
+}
+
+impl Deref for HunkHash {
+    type Target = md5::Digest;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for HunkHash {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl fmt::Debug for HunkHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.0, f)
+    }
+}
+
+impl fmt::LowerHex for HunkHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::LowerHex::fmt(&self.0, f)
+    }
+}
+
+impl fmt::UpperHex for HunkHash {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::UpperHex::fmt(&self.0, f)
+    }
+}

--- a/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
@@ -85,6 +85,7 @@ pub struct BranchUpdateRequest {
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct BranchSplitHunkUpdateRequest {
     pub hunk_hash: HunkHash,
+    pub split_from: Option<HunkHash>,
     pub lines: Vec<Option<BranchId>>,
 }
 

--- a/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
@@ -1,10 +1,12 @@
 mod file_ownership;
 mod hunk;
+mod hunk_hash;
 mod ownership;
 
 use anyhow::Result;
 pub use file_ownership::OwnershipClaim;
-pub use hunk::{Hunk, HunkHash};
+pub use hunk::Hunk;
+pub use hunk_hash::HunkHash;
 pub use ownership::{reconcile_claims, BranchOwnershipClaims};
 use serde::{Deserialize, Serialize};
 
@@ -82,10 +84,8 @@ pub struct BranchUpdateRequest {
 
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct BranchSplitHunkUpdateRequest {
-    pub id: BranchId,
-    pub source_id: BranchId,
-    pub ownership: String,
-    pub lines: Vec<(Option<i32>, Option<i32>)>,
+    pub hunk_hash: HunkHash,
+    pub lines: Vec<Option<BranchId>>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
+++ b/crates/gitbutler-core/src/virtual_branches/branch/mod.rs
@@ -81,6 +81,14 @@ pub struct BranchUpdateRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]
+pub struct BranchSplitHunkUpdateRequest {
+    pub id: BranchId,
+    pub source_id: BranchId,
+    pub ownership: String,
+    pub lines: Vec<(Option<i32>, Option<i32>)>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
 pub struct BranchCreateRequest {
     pub name: Option<String>,
     pub ownership: Option<BranchOwnershipClaims>,

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -183,7 +183,7 @@ impl Controller {
         &self,
         project_id: &ProjectId,
         branch_update: super::branch::BranchSplitHunkUpdateRequest,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         self.inner(*project_id)
             .await
             .split_hunk_and_update_virtual_branch(project_id, branch_update)
@@ -610,7 +610,7 @@ impl ControllerInner {
         &self,
         project_id: &ProjectId,
         branch_update: super::branch::BranchSplitHunkUpdateRequest,
-    ) -> Result<(), Error> {
+    ) -> Result<()> {
         let _permit = self.semaphore.acquire().await;
 
         self.with_verify_branch(*project_id, |project_repository, _| {

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -184,7 +184,7 @@ impl Controller {
         project_id: &ProjectId,
         branch_update: super::branch::BranchSplitHunkUpdateRequest,
     ) -> Result<(), Error> {
-        self.inner(project_id)
+        self.inner(*project_id)
             .await
             .split_hunk_and_update_virtual_branch(project_id, branch_update)
             .await
@@ -613,7 +613,7 @@ impl ControllerInner {
     ) -> Result<(), Error> {
         let _permit = self.semaphore.acquire().await;
 
-        self.with_verify_branch(project_id, |project_repository, _| {
+        self.with_verify_branch(*project_id, |project_repository, _| {
             let mut splits = project_repository.project().splits();
             splits.load()?;
             let split_entry = splits.get_mut_or_insert(branch_update.hunk_hash);

--- a/crates/gitbutler-core/src/virtual_branches/controller.rs
+++ b/crates/gitbutler-core/src/virtual_branches/controller.rs
@@ -178,6 +178,18 @@ impl Controller {
             .update_virtual_branch(project_id, branch_update)
             .await
     }
+
+    pub async fn split_hunk_and_update_virtual_branch(
+        &self,
+        project_id: &ProjectId,
+        branch_update: super::branch::BranchSplitHunkUpdateRequest,
+    ) -> Result<(), Error> {
+        self.inner(project_id)
+            .await
+            .split_hunk_and_update_virtual_branch(project_id, branch_update)
+            .await
+    }
+
     pub async fn delete_virtual_branch(
         &self,
         project_id: ProjectId,
@@ -592,6 +604,16 @@ impl ControllerInner {
             super::update_branch(project_repository, branch_update)?;
             Ok(())
         })
+    }
+
+    pub async fn split_hunk_and_update_virtual_branch(
+        &self,
+        project_id: &ProjectId,
+        _branch_update: super::branch::BranchSplitHunkUpdateRequest,
+    ) -> Result<(), Error> {
+        let _permit = self.semaphore.acquire().await;
+
+        self.with_verify_branch(project_id, |_project_repository, _| Ok(()))
     }
 
     pub async fn delete_virtual_branch(

--- a/crates/gitbutler-core/src/virtual_branches/mod.rs
+++ b/crates/gitbutler-core/src/virtual_branches/mod.rs
@@ -24,3 +24,5 @@ pub use remote::*;
 
 mod state;
 pub use state::VirtualBranchesHandle;
+
+pub mod split;

--- a/crates/gitbutler-core/src/virtual_branches/split.rs
+++ b/crates/gitbutler-core/src/virtual_branches/split.rs
@@ -1,0 +1,96 @@
+//! Provides all of the types and implementations
+//! necessary to manage the hunk split database.
+
+use anyhow::{Context, Result};
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    path::{Path, PathBuf},
+};
+
+use serde::{Deserialize, Serialize};
+
+use super::{branch::HunkHash, BranchId};
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct Splits {
+    split: HashMap<HunkHash, SplitEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SplitEntry {
+    pub ownership: Vec<BranchId>,
+}
+
+#[derive(Debug, Clone)]
+pub struct SplitDatabase {
+    path: PathBuf,
+    splits: Splits,
+}
+
+impl SplitDatabase {
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        Self {
+            splits: Splits::default(),
+            path: path.as_ref().to_path_buf(),
+        }
+    }
+
+    pub fn load(&mut self) -> Result<()> {
+        let file = match std::fs::File::open(&self.path) {
+            Ok(file) => file,
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::NotFound {
+                    return Ok(());
+                }
+                return Err(e).context("failed to open split database file");
+            }
+        };
+        let reader = std::io::BufReader::new(file);
+        self.splits = serde_json::from_reader(reader).context("failed to read split database")?;
+        Ok(())
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let file =
+            std::fs::File::create(&self.path).context("failed to create split database file")?;
+        serde_json::to_writer_pretty(file, &self.splits)
+            .context("failed to write split database")?;
+        Ok(())
+    }
+
+    pub fn get(&self, hash: &HunkHash) -> Option<&SplitEntry> {
+        self.splits.split.get(hash)
+    }
+
+    pub fn get_mut(&mut self, hash: &HunkHash) -> Option<&mut SplitEntry> {
+        self.splits.split.get_mut(hash)
+    }
+
+    pub fn get_mut_or_insert(&mut self, hash: HunkHash) -> &mut SplitEntry {
+        if let Entry::Vacant(e) = self.splits.split.entry(hash) {
+            e.insert(SplitEntry::default());
+        }
+
+        self.splits.split.get_mut(&hash).unwrap()
+    }
+
+    pub fn set(&mut self, hash: HunkHash, entry: SplitEntry) -> Option<SplitEntry> {
+        self.splits.split.insert(hash, entry)
+    }
+
+    pub fn splits(&self) -> &Splits {
+        &self.splits
+    }
+
+    pub fn splits_mut(&mut self) -> &mut Splits {
+        &mut self.splits
+    }
+
+    pub fn replace_splits(&mut self, splits: Splits) -> Splits {
+        std::mem::replace(&mut self.splits, splits)
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}

--- a/crates/gitbutler-core/src/virtual_branches/split.rs
+++ b/crates/gitbutler-core/src/virtual_branches/split.rs
@@ -16,7 +16,7 @@ pub struct Splits {
     split: HashMap<HunkHash, SplitEntry>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 pub struct SplitEntry {
     pub ownership: Vec<BranchId>,
 }

--- a/crates/gitbutler-core/src/virtual_branches/virtual.rs
+++ b/crates/gitbutler-core/src/virtual_branches/virtual.rs
@@ -148,6 +148,8 @@ pub struct VirtualBranchHunk {
     pub file_path: PathBuf,
     #[serde(serialize_with = "crate::serde::hash_to_hex")]
     pub hash: HunkHash,
+    #[serde(serialize_with = "crate::serde::hash_to_hex_opt")]
+    pub split_from: Option<HunkHash>,
     pub old_start: u32,
     pub start: u32,
     pub end: u32,
@@ -179,6 +181,7 @@ impl VirtualBranchHunk {
             end: hunk.new_start + hunk.new_lines,
             binary: hunk.binary,
             hash,
+            split_from: hunk.split_from,
             locked: hunk.locked_to.len() > 0,
             locked_to: Some(hunk.locked_to),
             change_type: hunk.change_type,
@@ -1953,8 +1956,9 @@ fn get_applied_status(
 
             let mut new_hunk = hunk.clone();
             new_hunk.diff_lines = BString::from_iter(content.into_iter());
+            new_hunk.split_from = Some(hunk_hash);
 
-            tracing::warn!("AFTER: {:?}", new_hunk.diff_lines);
+            tracing::warn!("AFTER: {:#?}", new_hunk);
 
             diffs_by_branch
                 .entry(virtual_branches[vbranch_pos].id)

--- a/crates/gitbutler-tauri/src/main.rs
+++ b/crates/gitbutler-tauri/src/main.rs
@@ -183,6 +183,7 @@ fn main() {
                     virtual_branches::commands::update_base_branch,
                     virtual_branches::commands::integrate_upstream_commits,
                     virtual_branches::commands::update_virtual_branch,
+                    virtual_branches::commands::split_hunk_and_update_virtual_branch,
                     virtual_branches::commands::delete_virtual_branch,
                     virtual_branches::commands::apply_branch,
                     virtual_branches::commands::unapply_branch,

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -179,12 +179,18 @@ pub mod commands {
     }
 
     #[tauri::command(async)]
-    #[instrument(skip(_handle), err(Debug))]
+    #[instrument(skip(handle), err(Debug))]
     pub async fn split_hunk_and_update_virtual_branch(
-        _handle: AppHandle,
+        handle: AppHandle,
         project_id: ProjectId,
         branch: branch::BranchSplitHunkUpdateRequest,
     ) -> Result<(), Error> {
+        handle
+            .state::<Controller>()
+            .split_hunk_and_update_virtual_branch(&project_id, branch)
+            .await?;
+
+        emit_vbranches(&handle, &project_id).await;
         Ok(())
     }
 

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -190,7 +190,7 @@ pub mod commands {
             .split_hunk_and_update_virtual_branch(&project_id, branch)
             .await?;
 
-        emit_vbranches(&handle, &project_id).await;
+        emit_vbranches(&handle, project_id).await;
         Ok(())
     }
 

--- a/crates/gitbutler-tauri/src/virtual_branches.rs
+++ b/crates/gitbutler-tauri/src/virtual_branches.rs
@@ -4,8 +4,8 @@ pub mod commands {
     use gitbutler_core::{
         assets,
         error::Code,
-        git, projects,
-        projects::ProjectId,
+        git,
+        projects::{self, ProjectId},
         virtual_branches::{
             branch::{self, BranchId, BranchOwnershipClaims},
             controller::Controller,
@@ -175,6 +175,16 @@ pub mod commands {
             .await?;
 
         emit_vbranches(&handle, project_id).await;
+        Ok(())
+    }
+
+    #[tauri::command(async)]
+    #[instrument(skip(_handle), err(Debug))]
+    pub async fn split_hunk_and_update_virtual_branch(
+        _handle: AppHandle,
+        project_id: ProjectId,
+        branch: branch::BranchSplitHunkUpdateRequest,
+    ) -> Result<(), Error> {
         Ok(())
     }
 


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the ability to split hunks and assign them to different branches. It includes changes to the core logic, UI components, and backend controllers to support this new feature. Enhancements were made to existing structures and components to accommodate hunk splitting, and additional logging was added for better debugging.

- **New Features**:
    - Introduced hunk splitting functionality, allowing hunks to be split and assigned to different branches.
    - Added a new `split_hunk_and_update_virtual_branch` function to the controller for handling hunk splits and updating branch ownership.
    - Implemented a new `DraggableSplitHunk` class for handling split hunks in the UI.
- **Enhancements**:
    - Updated the `VirtualBranchHunk` struct to include an optional `split_from` field.
    - Enhanced the `HunkViewer` component to support splitting hunks with a new checkbox and line selection mechanism.
    - Modified the `BranchCard` component to handle drops of `DraggableSplitHunk` instances.
    - Added logging to the IPC invoke and listen functions for better debugging.

<!-- Generated by sourcery-ai[bot]: end summary -->