### PR TITLE
Add better support for different forge web URLs, flatten BaseBranch f…

### DIFF
--- a/app/src/lib/components/BaseBranchSwitch.svelte
+++ b/app/src/lib/components/BaseBranchSwitch.svelte
@@ -20,7 +20,7 @@
 	let project = getContext(Project);
 
 	let selectedBranch = { name: $baseBranch.branchName };
-	let selectedRemote = { name: $baseBranch.actualPushRemoteName() };
+	let selectedRemote = { name: $baseBranch.actualPushRemoteName };
 	let targetChangeDisabled = false;
 
 	if ($activeBranches) {
@@ -94,7 +94,7 @@
 						bind:value={selectedRemote}
 						itemId="name"
 						labelId="name"
-						selectedItemId={$baseBranch.actualPushRemoteName()}
+						selectedItemId={$baseBranch.actualPushRemoteName}
 						disabled={targetChangeDisabled}
 						label="Create branches on remote"
 					>
@@ -129,7 +129,7 @@
 						id="set-base-branch"
 						loading={isSwitching}
 						disabled={(selectedBranch.name === $baseBranch.branchName &&
-							selectedRemote.name === $baseBranch.actualPushRemoteName()) ||
+							selectedRemote.name === $baseBranch.actualPushRemoteName) ||
 							targetChangeDisabled}
 					>
 						{isSwitching ? 'Switching branches...' : 'Update configuration'}

--- a/app/src/lib/utils/url.test.ts
+++ b/app/src/lib/utils/url.test.ts
@@ -1,34 +1,10 @@
-import { remoteUrlIsHttp, convertRemoteToWebUrl } from '$lib/utils/url';
+import { remoteUrlIsHttp } from '$lib/utils/url';
 import { describe, expect, test } from 'vitest';
 
 describe.concurrent('cleanUrl', () => {
-	test('it should handle url starts with http(s)?', () => {
-		expect(convertRemoteToWebUrl('https://github.com/user/repo.git')).toEqual(
-			'https://github.com/user/repo'
-		);
-	});
-
-	test('it should handle complete ssh url with domain name', () => {
-		expect(convertRemoteToWebUrl('ssh://git@github.com:22/user/repo.git')).toEqual(
-			'https://github.com/user/repo'
-		);
-	});
-
-	test('it should handle complete ssh url with ip', () => {
-		expect(convertRemoteToWebUrl('ssh://git@192.168.1.1:22/user/repo.git')).toEqual(
-			'http://192.168.1.1/user/repo'
-		);
-	});
-
-	test('it should handle SCP-like url', () => {
-		expect(convertRemoteToWebUrl('git@github.com:user/repo.git')).toEqual(
-			'https://github.com/user/repo'
-		);
-	});
-
 	const httpRemoteUrls = ['https://github.com/user/repo.git', 'http://192.168.1.1/user/repo.git'];
 
-	test.each(httpRemoteUrls)('HTTP Remote - %s', (remoteUrl) => {
+	test.each(httpRemoteUrls)('HTTP Remote - %s', (remoteUrl: string) => {
 		expect(remoteUrlIsHttp(remoteUrl)).toBe(true);
 	});
 
@@ -38,7 +14,7 @@ describe.concurrent('cleanUrl', () => {
 		'git://github.com/user/repo.git'
 	];
 
-	test.each(nonHttpRemoteUrls)('Non HTTP Remote - %s', (remoteUrl) => {
+	test.each(nonHttpRemoteUrls)('Non HTTP Remote - %s', (remoteUrl: string) => {
 		expect(remoteUrlIsHttp(remoteUrl)).toBe(false);
 	});
 });

--- a/app/src/lib/utils/url.ts
+++ b/app/src/lib/utils/url.ts
@@ -24,14 +24,7 @@ export async function openExternalUrl(href: string) {
 	}
 }
 
-// turn a git remote url into a web url (github, gitlab, bitbucket, etc)
-export function convertRemoteToWebUrl(url: string): string {
-	const gitRemote = GitUrlParse(url);
-	const ipv4Regex = new RegExp(/^([0-9]+(\.|$)){4}/);
-	const protocol = ipv4Regex.test(gitRemote.resource) ? 'http' : 'https';
-
-	return `${protocol}://${gitRemote.resource}/${gitRemote.owner}/${gitRemote.name}`;
-}
+export const ipv4Regex = new RegExp(/^([0-9]+(\.|$)){4}/);
 
 export function remoteUrlIsHttp(url: string): boolean {
 	const httpProtocols = ['http', 'https'];

--- a/app/src/lib/vbranches/baseBranch.ts
+++ b/app/src/lib/vbranches/baseBranch.ts
@@ -104,7 +104,15 @@ export class BaseBranchService {
 }
 
 async function getBaseBranch(params: { projectId: string }): Promise<BaseBranch | null> {
-	return plainToInstance(BaseBranch, await invoke<any>('get_base_branch_data', params));
+	return createBaseBranch(await invoke<any>('get_base_branch_data', params));
+}
+
+export function createBaseBranch(obj: any): BaseBranch {
+	const baseBranch = plainToInstance(BaseBranch, obj) as BaseBranch;
+	if (baseBranch) {
+		baseBranch.afterTransform();
+	}
+	return baseBranch;
 }
 
 export async function getRemoteBranches(projectId: string | undefined) {

--- a/app/src/lib/vbranches/types.test.ts
+++ b/app/src/lib/vbranches/types.test.ts
@@ -1,0 +1,148 @@
+import { createBaseBranch } from './baseBranch';
+import { BaseBranch, type ForgeType } from './types';
+import { expect, test, describe } from 'vitest';
+
+const forgeTestUrls: Record<ForgeType, Array<string>> = {
+	GitHub: [
+		'git@github.com:org/repo.git/',
+		'git@github.com:org/repo.git',
+		'git@github.com:org/repo',
+		'https://github.com/org/repo.git/',
+		'https://github.com/org/repo.git',
+		'https://github.com/org/repo',
+		'ssh://git@github.com:22/org/repo.git'
+	],
+	GitLab: ['git@gitlab.com:org/repo.git', 'https://gitlab.com/org/repo.git'],
+	Bitbucket: ['git@bitbucket.org:org/repo.git', 'https://user@bitbucket.org/org/repo.git'],
+	AzureDevOps: [
+		'https://user@dev.azure.com/org/project/_git/repo',
+		'git@ssh.dev.azure.com:v3/org/project/repo'
+	],
+	Unknown: ['https://otherdomain.com/org/repo']
+};
+
+describe.concurrent('BaseBranch', () => {
+	describe.each(Object.keys(forgeTestUrls).map((_) => _ as ForgeType))(
+		'parse %s as forge',
+		(forgeKey: ForgeType) => {
+			test('test collection not empty', () => {
+				expect(forgeTestUrls[forgeKey]).toBeTruthy();
+				expect(forgeTestUrls[forgeKey].length).not.toBe(0);
+			});
+
+			test.each(forgeTestUrls[forgeKey])('%s', (remoteUrl: string) => {
+				const baseBranch: BaseBranch = createBaseBranch({
+					remoteUrl: remoteUrl
+				});
+
+				expect(baseBranch.forgeType).toBe(forgeKey);
+			});
+		}
+	);
+
+	// The BranchService and get_base_branch_data inside of Rust should validate that this is always supplied but the
+	// previous typescript/svelte implementation supported this not being supplied so this one does as well
+	test('no pushRemoteUrl, does not throw', () => {
+		const baseBranch: BaseBranch = createBaseBranch({
+			remoteUrl: 'https://github.com/org/repo.git',
+			pushRemoteUrl: undefined
+		});
+		expect(baseBranch.commitBaseUrl).toEqual(undefined);
+	});
+
+	test('it should handle complete ssh url with ip', () => {
+		const remoteUrl = 'ssh://git@192.168.1.1:22/org/repo.git';
+		const baseBranch: BaseBranch = createBaseBranch({
+			remoteUrl: remoteUrl,
+			pushRemoteUrl: remoteUrl
+		});
+		expect(baseBranch.commitBaseUrl).toEqual('http://192.168.1.1/org/repo');
+	});
+
+	describe.each(Object.keys(forgeTestUrls))(
+		'parse %s for commit base url',
+		(forgeKey: ForgeType) => {
+			test('test collection not empty', () => {
+				expect(forgeTestUrls[forgeKey]).toBeTruthy();
+				expect(forgeTestUrls[forgeKey].length).not.toBe(0);
+			});
+
+			test.each(forgeTestUrls[forgeKey])('%s', (remoteUrl: string) => {
+				const baseBranch: BaseBranch = createBaseBranch({
+					remoteUrl: remoteUrl,
+					pushRemoteUrl: remoteUrl
+				});
+
+				switch (forgeKey) {
+					case 'GitHub':
+						expect(baseBranch.commitBaseUrl).toBe('https://github.com/org/repo');
+						break;
+					case 'GitLab':
+						expect(baseBranch.commitBaseUrl).toBe('https://gitlab.com/org/repo');
+						break;
+					case 'Bitbucket':
+						expect(baseBranch.commitBaseUrl).toBe('https://bitbucket.org/org/repo');
+						break;
+					case 'AzureDevOps':
+						expect(baseBranch.commitBaseUrl).toBe('https://dev.azure.com/org/project/_git/repo');
+						break;
+					case 'Unknown':
+						expect(baseBranch.commitBaseUrl).toBe('https://otherdomain.com/org/repo');
+						break;
+				}
+			});
+		}
+	);
+
+	describe.each(Object.keys(forgeTestUrls))('parse %s for commit url', (forgeKey: ForgeType) => {
+		test('test collection not empty', () => {
+			expect(forgeTestUrls[forgeKey]).toBeTruthy();
+			expect(forgeTestUrls[forgeKey].length).not.toBe(0);
+		});
+
+		test.each(forgeTestUrls[forgeKey])('%s', (remoteUrl: string) => {
+			const baseBranch: BaseBranch = createBaseBranch({
+				remoteUrl: remoteUrl,
+				pushRemoteUrl: remoteUrl
+			});
+
+			const commitId = 'abcdef';
+			switch (forgeKey) {
+				case 'GitHub':
+					expect(baseBranch.commitUrl(commitId)).toBe(
+						`https://github.com/org/repo/commit/${commitId}`
+					);
+					break;
+				case 'GitLab':
+					expect(baseBranch.commitUrl(commitId)).toBe(
+						`https://gitlab.com/org/repo/-/commit/${commitId}`
+					);
+					break;
+				case 'Bitbucket':
+					expect(baseBranch.commitUrl(commitId)).toBe(
+						`https://bitbucket.org/org/repo/commits/${commitId}`
+					);
+					break;
+				case 'AzureDevOps':
+					expect(baseBranch.commitUrl(commitId)).toBe(
+						`https://dev.azure.com/org/project/_git/repo/commit/${commitId}`
+					);
+					break;
+				case 'Unknown':
+					expect(baseBranch.commitUrl(commitId)).toBe(
+						`https://otherdomain.com/org/repo/commit/${commitId}`
+					);
+					break;
+			}
+		});
+	});
+
+	test('null is handled', () => {
+		const baseBranch: BaseBranch = createBaseBranch(null);
+
+		// Validate how it's handled in code
+		expect(baseBranch).toBeFalsy();
+		// Validate it's actually null
+		expect(baseBranch).toBeNull();
+	});
+});

--- a/app/src/lib/vbranches/types.ts
+++ b/app/src/lib/vbranches/types.ts
@@ -2,8 +2,9 @@ import 'reflect-metadata';
 import { splitMessage } from '$lib/utils/commitMessage';
 import { hashCode } from '$lib/utils/string';
 import { isDefined, notNull } from '$lib/utils/typeguards';
-import { convertRemoteToWebUrl } from '$lib/utils/url';
-import { Type, Transform } from 'class-transformer';
+import { ipv4Regex } from '$lib/utils/url';
+import { Expose, Type, Transform, type TransformFnParams } from 'class-transformer';
+import GitUrlParse from 'git-url-parse';
 
 export type ChangeType =
 	/// Entry does not exist in old version
@@ -370,12 +371,20 @@ export class RemoteBranchData {
 	}
 }
 
+export enum Forge {
+	Unknown,
+	GitHub,
+	GitLab,
+	Bitbucket,
+	AzureDevOps
+}
+
+export type ForgeType = keyof typeof Forge;
+
 export class BaseBranch {
 	branchName!: string;
 	remoteName!: string;
-	remoteUrl!: string;
 	pushRemoteName!: string;
-	pushRemoteUrl!: string;
 	baseSha!: string;
 	currentSha!: string;
 	behind!: number;
@@ -384,80 +393,126 @@ export class BaseBranch {
 	@Type(() => RemoteCommit)
 	recentCommits!: RemoteCommit[];
 	lastFetchedMs?: number;
+	forgeType: ForgeType | undefined;
+	remoteUrl!: string;
+	repoBaseUrl: string | undefined;
+	@Expose({ name: 'pushRemoteUrl' })
+	@Transform(({ value }: TransformFnParams) => (value ? GitUrlParse(value) : undefined))
+	gitPushRemote!: GitUrlParse.GitUrl | undefined;
+	commitBaseUrl: string | undefined;
+	actualPushRemoteName: string | undefined;
+	private generateCommitUrl: ((commitId: string) => string) | undefined;
+	private generateBranchUrl: ((baseBranchName: string, branchName: string) => string) | undefined;
 
-	actualPushRemoteName(): string {
-		return this.pushRemoteName || this.remoteName;
+	// TODO: Move most if not all of this to Rust to send over finalized properties from get_base_branch_data
+	// Make as many of the one-time business rules run once
+	afterTransform(): void {
+		const gitRemote = GitUrlParse(this.remoteUrl);
+		const remoteUrlProtocol = ipv4Regex.test(gitRemote.resource) ? 'http' : 'https';
+		this.repoBaseUrl = `${remoteUrlProtocol}://${gitRemote.resource}/${gitRemote.owner}/${gitRemote.name}`;
+		this.forgeType = this.getForgeType(gitRemote.resource);
+
+		this.actualPushRemoteName = this.pushRemoteName || this.remoteName;
+
+		if (this.gitPushRemote) {
+			const { organization, owner, name, protocol } = this.gitPushRemote;
+			let { resource } = this.gitPushRemote;
+			const webProtocol = ipv4Regex.test(resource) ? 'http' : 'https';
+
+			if (protocol === 'ssh' && resource.startsWith('ssh.')) {
+				resource = resource.slice(4);
+			}
+
+			if (this.forgeType === 'AzureDevOps') {
+				this.commitBaseUrl = `${webProtocol}://${resource}/${organization}/${owner}/_git/${name}`;
+			} else {
+				this.commitBaseUrl = `${webProtocol}://${resource}/${owner}/${name}`;
+			}
+
+			// Different Git providers use different paths for the commit url:
+			switch (this.forgeType) {
+				case 'Bitbucket':
+					this.generateCommitUrl = (commitId) => `${this.commitBaseUrl}/commits/${commitId}`;
+					break;
+				case 'GitLab':
+					this.generateCommitUrl = (commitId) => `${this.commitBaseUrl}/-/commit/${commitId}`;
+					break;
+				case 'AzureDevOps':
+				case 'GitHub':
+				case 'Unknown':
+				default:
+					this.generateCommitUrl = (commitId) => `${this.commitBaseUrl}/commit/${commitId}`;
+					break;
+			}
+		}
+
+		if (this.gitPushRemote) {
+			if (this.pushRemoteName) {
+				if (this.forgeType === 'GitHub') {
+					// master...schacon:docs:Virtual-branch
+					const pushUsername = this.gitPushRemote.user;
+					const pushRepoName = this.gitPushRemote.name;
+					this.generateBranchUrl = (baseBranchName, branchName) =>
+						`${this.repoBaseUrl}/compare/${baseBranchName}...${pushUsername}:${pushRepoName}:${branchName}`;
+				}
+			}
+
+			if (!this.generateBranchUrl) {
+				switch (this.forgeType) {
+					case 'Bitbucket':
+						this.generateBranchUrl = (baseBranchName, branchName) =>
+							`${this.repoBaseUrl}/branch/${branchName}?dest=${baseBranchName}`;
+						break;
+					case 'AzureDevOps':
+						this.generateBranchUrl = (baseBranchName, branchName) =>
+							`${this.commitBaseUrl}/branchCompare?baseVersion=GB${baseBranchName}&targetVersion=GB${branchName}`;
+						break;
+					// The following branch path is good for at least Gitlab and Github:
+					case 'GitHub':
+					case 'GitLab':
+					case 'Unknown':
+					default:
+						this.generateBranchUrl = (baseBranchName, branchName) =>
+							`${this.repoBaseUrl}/compare/${baseBranchName}...${branchName}`;
+						break;
+				}
+			}
+		}
+	}
+
+	private getForgeType(repoBaseUrl: string): ForgeType {
+		switch (true) {
+			case repoBaseUrl.includes('github.com'):
+				return 'GitHub';
+			case repoBaseUrl.includes('gitlab.com'):
+				return 'GitLab';
+			case repoBaseUrl.includes('bitbucket.org'):
+				return 'Bitbucket';
+			case repoBaseUrl.includes('dev.azure.com'):
+				return 'AzureDevOps';
+			default:
+				return 'Unknown';
+		}
 	}
 
 	get lastFetched(): Date | undefined {
 		return this.lastFetchedMs ? new Date(this.lastFetchedMs) : undefined;
 	}
 
-	get pushRepoBaseUrl(): string {
-		return convertRemoteToWebUrl(this.pushRemoteUrl);
-	}
-
-	get repoBaseUrl(): string {
-		return convertRemoteToWebUrl(this.remoteUrl);
-	}
-
 	commitUrl(commitId: string): string | undefined {
-		// Different Git providers use different paths for the commit url:
-		if (this.isBitBucket) {
-			return `${this.pushRepoBaseUrl}/commits/${commitId}`;
-		}
-		if (this.isGitlab) {
-			return `${this.pushRepoBaseUrl}/-/commit/${commitId}`;
-		}
-		return `${this.pushRepoBaseUrl}/commit/${commitId}`;
+		return this.generateCommitUrl ? this.generateCommitUrl(commitId) : undefined;
 	}
 
 	get shortName() {
 		return this.branchName.split('/').slice(-1)[0];
 	}
 
-	branchUrl(upstreamBranchName: string | undefined) {
-		if (!upstreamBranchName) return undefined;
+	branchUrl(upstreamBranchName: string | undefined): string | undefined {
+		if (!upstreamBranchName || !this.gitPushRemote || !this.generateBranchUrl) return undefined;
+		// parameter and variable property, always calculate unless future memoization
 		const baseBranchName = this.branchName.split('/')[1];
 		const branchName = upstreamBranchName.split('/').slice(3).join('/');
 
-		if (this.pushRemoteName) {
-			if (this.isGitHub) {
-				// master...schacon:docs:Virtual-branch
-				const pushUsername = this.extractUsernameFromGitHubUrl(this.pushRemoteUrl);
-				const pushRepoName = this.extractRepoNameFromGitHubUrl(this.pushRemoteUrl);
-				return `${this.repoBaseUrl}/compare/${baseBranchName}...${pushUsername}:${pushRepoName}:${branchName}`;
-			}
-		}
-
-		if (this.isBitBucket) {
-			return `${this.repoBaseUrl}/branch/${branchName}?dest=${baseBranchName}`;
-		}
-		// The following branch path is good for at least Gitlab and Github:
-		return `${this.repoBaseUrl}/compare/${baseBranchName}...${branchName}`;
-	}
-
-	private extractUsernameFromGitHubUrl(url: string): string | null {
-		const regex = /github\.com[/:]([a-zA-Z0-9_-]+)\/.*/;
-		const match = url.match(regex);
-		return match ? match[1] : null;
-	}
-
-	private extractRepoNameFromGitHubUrl(url: string): string | null {
-		const regex = /github\.com[/:]([a-zA-Z0-9_-]+)\/([a-zA-Z0-9_-]+)/;
-		const match = url.match(regex);
-		return match ? match[2] : null;
-	}
-
-	private get isGitHub(): boolean {
-		return this.repoBaseUrl.includes('github.com');
-	}
-
-	private get isBitBucket(): boolean {
-		return this.repoBaseUrl.includes('bitbucket.org');
-	}
-
-	private get isGitlab(): boolean {
-		return this.repoBaseUrl.includes('gitlab.com');
+		return this.generateBranchUrl(baseBranchName, branchName);
 	}
 }


### PR DESCRIPTION
…rom repeat logic.

## ☕️ Reasoning
- Support for Azure DevOps branch and commit URLs
- Easier future support for more forge types without deep integrations

## 🧢 Changes

- Moved forge type from a collection of Boolean functions to their own type, new Azure DevOps, and a default Unknown.
- Added test cases for each forge type.
- Flattened `BaseBranch` logic to do potentially repetitive work once, most of which could be simplified further if moved to the rust side still.
- Moved some logic around to better support performing string actions once, namely `convertRemoteToWebUrl` and tests there of.

<!--
If this PR is related to a specific issue, uncomment this section
and link it via the following text:

## 🎫 Affected issues

Fixes: INSERT_ISSUE_NUMBER

-->

<!--
If this is a WIP PR and you have todos left, feel free to uncomment this and turn this PR into a draft, see https://github.blog/2019-02-14-introducing-draft-pull-requests/

## 📌 Todos

-->

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the support for different forge web URLs, including Azure DevOps, by refactoring the forge type handling and simplifying the BaseBranch logic. It also includes comprehensive tests to ensure the correctness of the new functionality.

- **New Features**:
    - Added support for Azure DevOps branch and commit URLs.
- **Enhancements**:
    - Refactored forge type handling by introducing a new Forge enum and associated type.
    - Simplified BaseBranch logic by consolidating repetitive operations and moving some logic to Rust.
    - Improved URL handling by removing the convertRemoteToWebUrl function and integrating GitUrlParse for URL parsing.
- **Tests**:
    - Added test cases for each forge type to ensure correct URL parsing and commit URL generation.
    - Introduced tests to validate the handling of various remote URLs, including edge cases like SSH URLs with IP addresses.

<!-- Generated by sourcery-ai[bot]: end summary -->